### PR TITLE
Chnage C++ standard to 2017 and remove 2020 features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEBUG=-ggdb
 
 CXX=g++
-CXXFLAGS=-std=c++20 -Wall -Wextra -O3 -march=native -pthread $(DEBUG)
+CXXFLAGS=-std=c++17 -Wall -Wextra -O3 -march=native -pthread $(DEBUG)
 CXX_LDFLAGS=-ltbb
 
 all: trapezoidal.exe

--- a/trapezoidal.cpp
+++ b/trapezoidal.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
-#include <execution>
+//#include <execution>
 #include <numeric>
 #include <iterator>
 #include <array>
@@ -38,7 +38,7 @@ int main()
     // Initialize the x-coordinates array
     transform
     (
-        execution::par_unseq,
+  //      execution::par_unseq,
         begin(indices), end(indices),
         begin(x),
         [&](auto const& index)
@@ -50,7 +50,7 @@ int main()
     // Initialize the function array
     transform
     (
-        execution::par_unseq,
+    //    execution::par_unseq,
         begin(indices), end(indices),
         begin(f),
         [&](auto const& index)


### PR DESCRIPTION
The GCC compiler installed on the cluster does not support C++-20